### PR TITLE
Center wallet button and update IPFS instructions

### DIFF
--- a/src/components/IPFSConfig.tsx
+++ b/src/components/IPFSConfig.tsx
@@ -33,7 +33,7 @@ const IPFSConfig = ({ onConfigured, isConfigured }: IPFSConfigProps) => {
       <CardHeader>
         <CardTitle>Configure IPFS Storage</CardTitle>
         <CardDescription>
-          IPFS metadata uploads are handled by your Railway backend service.
+          IPFS metadata uploads are handled by your backend service.
           <br />
           Make sure your backend is deployed with Pinata API keys configured.
         </CardDescription>

--- a/src/components/WalletConnect.tsx
+++ b/src/components/WalletConnect.tsx
@@ -141,7 +141,7 @@ export const WalletConnect: React.FC<WalletConnectProps> = ({
   }, [onConnect, onDisconnect]); // Dependencies: ensure callbacks are always up-to-date
 
   return (
-    <div className="flex items-center gap-4">
+    <div className="fixed bottom-8 left-1/2 transform -translate-x-1/2 flex items-center gap-4">
       {connected ? (
         <div className="flex items-center gap-2 bg-accent/80 backdrop-blur-sm px-4 py-2 rounded-lg">
           <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -386,7 +386,7 @@ const Index: React.FC<IndexProps> = ({
               <div className="mb-8">
                 <h2 className="text-2xl font-bold text-center mb-4">IPFS Configuration</h2>
                 <p className="text-center text-muted-foreground">
-                  Configure Pinata API keys to upload metadata to IPFS.
+                  Configure <a href="https://pinata.cloud/" className="underline" target="_blank" rel="noopener noreferrer">Piñata API Keys</a> to upload metadata to IPFS.
                 </p>
               </div>
 


### PR DESCRIPTION
## Summary
- Center the Connect Wallet button at the bottom of the page for improved visibility
- Link Piñata API Keys text to pinata.cloud and refine IPFS instructions
- Refer to a generic backend service in IPFS configuration messaging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 24 problems (18 errors, 6 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689bcef134fc832d9006d8ad5b9b2fc9