### PR TITLE
chore: expand IPFS metadata field mapping

### DIFF
--- a/carbon-nft-backend/src/services/ipfs.js
+++ b/carbon-nft-backend/src/services/ipfs.js
@@ -1,36 +1,67 @@
 const axios = require('axios');
 
 function createNFTMetadata(item) {
+  // Handle different possible field names from CSV
+  const serialNumber = item.serialNumber || item.SerialNumber || item['Serial Number'] || 'Unknown';
+  const projectName =
+    item.projectName ||
+    item.ProjectName ||
+    item['Project Name'] ||
+    item.ProjectID ||
+    item['Project ID'] ||
+    'N/A';
+  const country =
+    item.country ||
+    item.Country ||
+    item.GeographicCoordinates ||
+    item['Geographic Coordinates'] ||
+    'N/A';
+  const methodology = item.methodology || item.Methodology || 'N/A';
+  const vintage =
+    item.vintage ||
+    item.Vintage ||
+    item.VintageYear ||
+    item['Vintage Year'] ||
+    'N/A';
+  const volume =
+    item.volume ||
+    item.Volume ||
+    item.CarbonQuantity ||
+    item['Carbon Quantity'] ||
+    '1 tCO2e';
+
   return {
-    name: `Carbon Credit NFT - Serial: ${item.serialNumber}`,
-    description: "A tokenized carbon credit representing verified environmental impact.",
-    image: "https://images.unsplash.com/photo-1611273426858-450d8e3c9fce?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80",
+    name: `Carbon Credit NFT - Serial: ${serialNumber}`,
+    description:
+      'A tokenized carbon credit representing verified environmental impact.',
+    image:
+      'https://images.unsplash.com/photo-1611273426858-450d8e3c9fce?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80',
     attributes: [
       {
-        trait_type: "Serial Number",
-        value: item.serialNumber
+        trait_type: 'Serial Number',
+        value: serialNumber,
       },
       {
-        trait_type: "Project Name", 
-        value: item.projectName || "N/A"
+        trait_type: 'Project Name',
+        value: projectName,
       },
       {
-        trait_type: "Country",
-        value: item.country || "N/A"
+        trait_type: 'Country/Location',
+        value: country,
       },
       {
-        trait_type: "Methodology",
-        value: item.methodology || "N/A"
+        trait_type: 'Methodology',
+        value: methodology,
       },
       {
-        trait_type: "Vintage",
-        value: item.vintage || "N/A"
+        trait_type: 'Vintage',
+        value: vintage,
       },
       {
-        trait_type: "Volume",
-        value: item.volume || "1 tCO2e"
-      }
-    ]
+        trait_type: 'Volume',
+        value: volume,
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary
- support multiple CSV field name variants when generating NFT metadata
- expose consistent attribute names for country, project, and other details

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: 14 errors, 6 warnings)


------
https://chatgpt.com/codex/tasks/task_e_689bd442e0d8832da97573e473ca783d