### PR TITLE
Hide Lovable badge

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -93,4 +93,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  lovable-badge,
+  .lovable-badge,
+  #lovable-badge {
+    display: none !important;
+  }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,4 +2,15 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-createRoot(document.getElementById("root")!).render(<App />);
+const root = createRoot(document.getElementById('root')!)
+root.render(<App />)
+
+const interval = setInterval(() => {
+  const badge = document.querySelector(
+    'lovable-badge, .lovable-badge, #lovable-badge',
+  ) as HTMLElement | null
+  if (badge) {
+    badge.remove()
+    clearInterval(interval)
+  }
+}, 100)


### PR DESCRIPTION
## Summary
- remove Lovable badge after app mount by polling document
- hide Lovable badge with global CSS rule

## Testing
- `npm run lint` *(fails: Unexpected any and other existing issues)*

------
https://chatgpt.com/codex/tasks/task_e_689bfc7cf220832d895b299dd0a1afcb