### PR TITLE
Remove duplicate wallet connect button

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -811,16 +811,6 @@ const Index: React.FC<IndexProps> = ({
             </div>
           )}
         </main>
-        {!walletConnected && (
-          <div className="mt-12 flex justify-center">
-            <WalletConnect
-              onConnect={handleWalletConnect}
-              onDisconnect={handleWalletDisconnect}
-              connected={walletConnected}
-              currentAddress={walletAddress}
-            />
-          </div>
-        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Remove extra `WalletConnect` component at bottom of Index page to prevent duplicate connect button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d1116598c832d9a6ea0559097273d