### PR TITLE
Handle dynamic solc contract output and clean up API

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -33,17 +33,13 @@ export function useContract() {
         description: "Compiling smart contract...",
       });
 
-      const compilationResult = await compileContract(sourceCode);
-      
-      if (!compilationResult.success) {
-        throw new Error(`Compilation failed: ${compilationResult.errors.join(', ')}`);
-      }
+      const { abi, bytecode } = await compileContract(sourceCode);
 
-      setContractState(prev => ({ 
-        ...prev, 
-        isCompiling: false, 
-        abi: compilationResult.abi,
-        isDeploying: true 
+      setContractState(prev => ({
+        ...prev,
+        isCompiling: false,
+        abi,
+        isDeploying: true
       }));
 
       toast({
@@ -53,8 +49,8 @@ export function useContract() {
 
       // Deploy contract
       const deploymentResult = await deployContract(
-        compilationResult.abi,
-        compilationResult.bytecode,
+        abi,
+        bytecode,
         signer
       );
 
@@ -76,7 +72,7 @@ export function useContract() {
       return {
         success: true,
         contractAddress: deploymentResult.contractAddress!,
-        abi: compilationResult.abi,
+        abi,
       };
     } catch (error) {
       setContractState(prev => ({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,8 +3,6 @@ const API_BASE_URL = import.meta.env.VITE_BACKEND_URL || 'https://africoin.up.ra
 export interface CompilationResult {
   abi: any[];
   bytecode: string;
-  success: boolean;
-  errors: string[];
 }
 
 export interface IPFSUploadResult {
@@ -35,17 +33,13 @@ export async function compileContract(sourceCode: string): Promise<CompilationRe
     });
 
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      const errorData = await response.json().catch(() => ({}));
+      throw new Error(errorData.message || `HTTP error! status: ${response.status}`);
     }
 
     return await response.json();
   } catch (error) {
-    return {
-      abi: [],
-      bytecode: '',
-      success: false,
-      errors: [error instanceof Error ? error.message : 'Network error'],
-    };
+    throw new Error(error instanceof Error ? error.message : 'Network error');
   }
 }
 

--- a/src/lib/contract-compiler.ts
+++ b/src/lib/contract-compiler.ts
@@ -3,8 +3,6 @@ import { compileContract as compileContractAPI } from './api';
 export interface CompilationResult {
   abi: any[];
   bytecode: string;
-  success: boolean;
-  errors: string[];
 }
 
 export async function compileContract(sourceCode: string): Promise<CompilationResult> {


### PR DESCRIPTION
## Summary
- allow compiler to select first compiled contract and report errors
- simplify compilation API to return just abi and bytecode
- adjust frontend hooks to use new compilation result

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: Unexpected any, no-empty, etc.)
- `cd carbon-nft-backend && npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689d2e7f562c832db2225e7031b78f83