### PR TITLE
Simplify minting button label

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -804,7 +804,7 @@ const Index: React.FC<IndexProps> = ({
                       disabled={mintingInProgress || uploadedURIs.length === 0}
                       className="px-8 py-3 bg-primary text-primary-foreground rounded-lg hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      {mintingInProgress ? 'Minting in Progress...' : 'Start Minting NFTs'}
+                      {mintingInProgress ? 'Minting in Progress...' : 'Mint NFTs'}
                     </button>
                   </div>
 


### PR DESCRIPTION
## Summary
- change minting button text from "Start Minting NFTs" to "Mint NFTs"

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 39 problems including @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_689d5af5eda0832dac321516b449cd98